### PR TITLE
Refine mobile layout across shared and page styles

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -2,12 +2,22 @@
   --gradient-primary: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   --gradient-success: linear-gradient(135deg, #48bb78 0%, #38a169 100%);
   --gradient-danger: linear-gradient(135deg, #f56565 0%, #e53e3e 100%);
-  
+
   /* Safe area insets */
   --safe-top: env(safe-area-inset-top);
   --safe-right: env(safe-area-inset-right);
   --safe-bottom: env(safe-area-inset-bottom);
   --safe-left: env(safe-area-inset-left);
+
+  /* Global layout scales */
+  --page-max-width: 1200px;
+  --page-padding-y: clamp(1.75rem, 5vw, 2.75rem);
+  --page-padding-x: clamp(1.25rem, 5vw, 2.5rem);
+  --card-padding: clamp(1.25rem, 4vw, 2rem);
+  --card-radius: clamp(0.75rem, 2.5vw, 1rem);
+  --section-gap: clamp(1rem, 4vw, 2rem);
+  --grid-gap: clamp(0.75rem, 3vw, 1.5rem);
+  --stack-gap: clamp(0.75rem, 3vw, 1.25rem);
 }
 
 * {
@@ -20,6 +30,7 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
   background: var(--gradient-primary);
   min-height: 100vh;
+  line-height: 1.5;
   /* Prevent horizontal scroll */
   overflow-x: hidden;
   /* Smooth scrolling on iOS */
@@ -66,18 +77,55 @@ a.action-card,
    ============================================ */
 .card, .summary-card, .table-card {
   background: white;
-  border-radius: 15px;
-  padding: 30px;
-  margin-bottom: 20px;
+  border-radius: var(--card-radius);
+  padding: var(--card-padding);
+  margin-bottom: var(--section-gap);
   box-shadow: 0 2px 10px rgba(0,0,0,0.1);
 }
 
 .container {
   min-height: 100vh;
   background: #f7fafc;
-  padding: 40px 20px;
-  max-width: 1200px;
+  padding: var(--page-padding-y) var(--page-padding-x);
+  width: min(100%, var(--page-max-width));
   margin: 0 auto;
+}
+
+.page-shell {
+  width: min(100%, var(--page-max-width));
+  margin: 0 auto;
+  padding: var(--page-padding-y) var(--page-padding-x);
+}
+
+.stack {
+  display: flex;
+  gap: var(--stack-gap);
+}
+
+.stack.wrap {
+  flex-wrap: wrap;
+}
+
+.stack.center {
+  align-items: center;
+}
+
+.auto-grid {
+  display: grid;
+  gap: var(--grid-gap);
+  grid-template-columns: repeat(auto-fit, minmax(min(var(--grid-min, 260px), 100%), 1fr));
+}
+
+h1 {
+  font-size: clamp(1.8rem, 2vw + 1.4rem, 2.6rem);
+}
+
+h2 {
+  font-size: clamp(1.35rem, 1.5vw + 1rem, 2rem);
+}
+
+h3 {
+  font-size: clamp(1.1rem, 1.2vw + 0.9rem, 1.6rem);
 }
 
 /* ============================================
@@ -174,18 +222,18 @@ tr:hover {
     padding-top: 56px; /* Height of mobile nav */
     padding-bottom: calc(60px + var(--safe-bottom)); /* Height of bottom nav + safe area */
   }
-  
+
   /* Container adjustments */
   .container {
-    padding: 20px 15px;
+    padding: calc(var(--page-padding-y) * 0.75) calc(var(--page-padding-x) * 0.85);
     padding-bottom: calc(80px + var(--safe-bottom));
   }
-  
+
   /* Card adjustments */
   .card, .summary-card, .table-card {
-    padding: 20px;
-    border-radius: 12px;
-    margin-bottom: 15px;
+    padding: calc(var(--card-padding) * 0.85);
+    border-radius: clamp(0.75rem, 2vw, 0.9rem);
+    margin-bottom: clamp(0.75rem, 3vw, 1.25rem);
   }
   
   /* Form improvements */
@@ -214,7 +262,7 @@ tr:hover {
   /* Grid adjustments */
   .action-grid, .nanny-grid, .stats-grid {
     grid-template-columns: 1fr !important;
-    gap: 1rem;
+    gap: var(--grid-gap);
   }
   
   /* Table adjustments */
@@ -274,7 +322,7 @@ tr:hover {
   /* Stats grid - 2 columns on mobile */
   .summary-stats {
     grid-template-columns: repeat(2, 1fr) !important;
-    gap: 0.75rem;
+    gap: var(--grid-gap);
   }
   
   .stat {
@@ -368,10 +416,10 @@ tr:hover {
 
 /* Visibility utilities */
 .mobile-only { display: none !important; }
-.desktop-only { display: block !important; }
+.desktop-only { display: revert; }
 
 @media (max-width: 768px) {
-  .mobile-only { display: block !important; }
+  .mobile-only { display: revert !important; }
   .desktop-only { display: none !important; }
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -60,8 +60,8 @@
   }
 </script>
 
-<div class="container">
-  <div class="card">
+<div class="auth-screen">
+  <div class="auth-card">
     <h1>Family Hub</h1>
     <h2>{mode === 'login' ? 'Welcome Back' : 'Create Account'}</h2>
     
@@ -107,98 +107,109 @@
 </div>
 
 <style>
-  .container {
+  .auth-screen {
     min-height: 100vh;
     display: flex;
     align-items: center;
     justify-content: center;
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    padding: 20px;
+    padding: clamp(1.5rem, 6vw, 3rem);
   }
-  
-  .card {
+
+  .auth-card {
     background: white;
-    padding: 40px;
-    border-radius: 15px;
+    padding: clamp(1.75rem, 6vw, 2.75rem);
+    border-radius: clamp(0.75rem, 3vw, 1.25rem);
     box-shadow: 0 10px 30px rgba(0,0,0,0.2);
-    max-width: 400px;
+    max-width: 420px;
     width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
   }
-  
+
   h1 {
     text-align: center;
-    font-size: 2.5em;
-    margin-bottom: 10px;
+    font-size: clamp(2rem, 4vw, 2.6rem);
     color: #667eea;
   }
-  
+
   h2 {
     text-align: center;
     color: #4a5568;
-    margin-bottom: 30px;
+    font-size: clamp(1.1rem, 2vw, 1.4rem);
   }
-  
+
   .error {
     background: #fff2f0;
     border: 1px solid #ffccc7;
     color: #a8071a;
-    padding: 12px;
-    border-radius: 8px;
-    margin-bottom: 20px;
+    padding: 0.75rem;
+    border-radius: 0.75rem;
   }
-  
+
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
   .input-group {
-    margin-bottom: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
   }
-  
+
   label {
-    display: block;
-    margin-bottom: 8px;
     color: #4a5568;
     font-weight: 500;
   }
-  
+
   input {
     width: 100%;
-    padding: 12px;
+    padding: 0.75rem;
     border: 1px solid #e2e8f0;
-    border-radius: 8px;
-    font-size: 1em;
+    border-radius: 0.75rem;
+    font-size: 1rem;
   }
-  
+
   input:focus {
     outline: none;
     border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
   }
-  
+
   button[type="submit"] {
     width: 100%;
-    padding: 14px;
+    padding: clamp(0.85rem, 3vw, 1rem);
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     color: white;
     border: none;
-    border-radius: 8px;
-    font-size: 1.1em;
+    border-radius: 0.75rem;
+    font-size: clamp(1rem, 2vw, 1.15rem);
     font-weight: 600;
     cursor: pointer;
     transition: transform 0.2s;
   }
-  
+
   button[type="submit"]:hover:not(:disabled) {
     transform: translateY(-2px);
   }
-  
+
   button[type="submit"]:disabled {
     opacity: 0.6;
     cursor: not-allowed;
   }
-  
+
   .toggle {
     text-align: center;
-    margin-top: 20px;
     color: #718096;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.95rem;
   }
-  
+
   .link {
     background: none;
     border: none;
@@ -206,12 +217,7 @@
     cursor: pointer;
     font-weight: 600;
     text-decoration: underline;
-  }
-
-  @media (max-width: 480px) {
-    .card { padding: 24px; }
-    h1 { font-size: 1.8em; }
-    h2 { font-size: 1.1em; }
+    font-size: 1rem;
   }
 </style>
 

--- a/src/routes/schedule/+page.svelte
+++ b/src/routes/schedule/+page.svelte
@@ -676,7 +676,7 @@
 
       <!-- Schedule Grid View -->
       {#if viewMode === 'grid'}
-        <div class="calendar">
+        <div class="calendar auto-grid">
           {#each getWeekDays() as day}
             <div class="day-column">
               <div class="day-header">
@@ -1010,27 +1010,8 @@
   
   /* Calendar Grid */
   .calendar {
-    display: grid;
-    grid-template-columns: repeat(7, 1fr);
-    gap: 15px;
-  }
-  
-  @media (max-width: 1024px) {
-    .calendar {
-      grid-template-columns: repeat(4, 1fr);
-    }
-  }
-  
-  @media (max-width: 768px) {
-    .calendar {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-  
-  @media (max-width: 480px) {
-    .calendar {
-      grid-template-columns: 1fr;
-    }
+    --grid-min: 160px;
+    gap: var(--grid-gap);
   }
   
   .day-column {

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -226,11 +226,11 @@
   
   .info-box {
     background: #f7fafc;
-    padding: 15px;
-    border-radius: 8px;
-    margin-bottom: 30px;
+    padding: clamp(1rem, 3vw, 1.5rem);
+    border-radius: 0.75rem;
+    margin-bottom: 2rem;
     color: #4a5568;
-    line-height: 1.8;
+    line-height: 1.7;
   }
   
   .admin-badge {
@@ -245,27 +245,29 @@
   }
   
   .form-group {
-    margin-bottom: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
   }
-  
+
   label {
-    display: block;
-    margin-bottom: 8px;
     color: #4a5568;
     font-weight: 500;
   }
-  
+
   input, select {
     width: 100%;
-    padding: 12px;
+    padding: 0.75rem;
     border: 1px solid #e2e8f0;
-    border-radius: 8px;
-    font-size: 1em;
+    border-radius: 0.75rem;
+    font-size: 1rem;
   }
-  
+
   input:focus, select:focus {
     outline: none;
     border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
   }
   
   small {
@@ -276,9 +278,9 @@
   }
   
   .btn {
-    padding: 12px 24px;
+    padding: clamp(0.75rem, 3vw, 1rem) clamp(1.5rem, 4vw, 2rem);
     border: none;
-    border-radius: 8px;
+    border-radius: 0.75rem;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.2s;
@@ -288,7 +290,7 @@
     width: 100%;
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     color: white;
-    font-size: 1.1em;
+    font-size: clamp(1rem, 2vw, 1.15rem);
   }
   
   .btn-primary:hover:not(:disabled) {
@@ -300,17 +302,17 @@
     opacity: 0.6;
     cursor: not-allowed;
   }
-  
+
   .btn-secondary {
     background: white;
     color: #667eea;
     border: 2px solid #667eea;
   }
-  
+
   .btn-secondary:hover {
     background: #f7fafc;
   }
-  
+
   .loading {
     min-height: 100vh;
     display: flex;
@@ -318,10 +320,5 @@
     justify-content: center;
     background: #f7fafc;
     color: #718096;
-  }
-  
-  @media (max-width: 480px) {
-    .container { padding: 20px 16px; }
-    .card { padding: 20px; }
   }
 </style>

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -58,8 +58,8 @@
   }
 </script>
 
-<div class="container">
-  <div class="card">
+<div class="setup-screen">
+  <div class="setup-card">
     <h1>Welcome to Family Hub!</h1>
     <h2>Let's get you set up</h2>
     
@@ -131,145 +131,144 @@
 </div>
 
 <style>
-  .container {
+  .setup-screen {
     min-height: 100vh;
     display: flex;
     align-items: center;
     justify-content: center;
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    padding: 20px;
+    padding: clamp(1.5rem, 6vw, 3rem);
   }
-  
-  .card {
+
+  .setup-card {
     background: white;
-    padding: 40px;
-    border-radius: 15px;
+    padding: clamp(1.75rem, 6vw, 3rem);
+    border-radius: clamp(0.75rem, 3vw, 1.25rem);
     box-shadow: 0 10px 30px rgba(0,0,0,0.2);
-    max-width: 500px;
+    max-width: 520px;
     width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
   }
-  
+
   h1 {
     text-align: center;
-    font-size: 2em;
-    margin-bottom: 10px;
+    font-size: clamp(1.9rem, 3vw, 2.4rem);
+    margin-bottom: 0.25rem;
     color: #667eea;
   }
-  
+
   h2 {
     text-align: center;
     color: #4a5568;
-    margin-bottom: 30px;
-    font-size: 1.3em;
+    font-size: clamp(1.1rem, 2vw, 1.4rem);
   }
-  
+
   .role-selection {
-    margin-bottom: 30px;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
   }
-  
+
   .role-card {
-    display: block;
     position: relative;
-    margin-bottom: 15px;
     cursor: pointer;
   }
-  
+
   .role-card input[type="radio"] {
     position: absolute;
     opacity: 0;
   }
-  
+
   .role-content {
-    padding: 20px;
+    padding: 1.25rem;
     border: 2px solid #e2e8f0;
-    border-radius: 10px;
+    border-radius: 0.75rem;
     transition: all 0.3s;
     text-align: center;
   }
-  
+
   .role-card:hover .role-content {
     border-color: #667eea;
     background: #f7fafc;
   }
-  
+
   .role-card.selected .role-content {
     border-color: #667eea;
-    background: linear-gradient(135deg, rgba(102, 126, 234, 0.1) 0%, rgba(118, 75, 162, 0.1) 100%);
+    background: linear-gradient(135deg, rgba(102, 126, 234, 0.12) 0%, rgba(118, 75, 162, 0.12) 100%);
   }
-  
+
   .role-icon {
-    font-size: 3em;
-    margin-bottom: 10px;
+    font-size: clamp(2.25rem, 6vw, 3rem);
+    margin-bottom: 0.75rem;
   }
-  
+
   .role-name {
-    font-size: 1.2em;
+    font-size: clamp(1.1rem, 2.5vw, 1.3rem);
     font-weight: 600;
     color: #2d3748;
-    margin-bottom: 5px;
+    margin-bottom: 0.25rem;
   }
-  
+
   .role-desc {
-    font-size: 0.9em;
+    font-size: 0.9rem;
     color: #718096;
   }
-  
+
   .details-form {
     border-top: 2px solid #e2e8f0;
-    padding-top: 30px;
+    padding-top: 1.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
   }
-  
+
   .input-group {
-    margin-bottom: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
   }
-  
+
   label {
-    display: block;
-    margin-bottom: 8px;
     color: #4a5568;
     font-weight: 500;
   }
-  
+
   input {
     width: 100%;
-    padding: 12px;
+    padding: 0.75rem;
     border: 1px solid #e2e8f0;
-    border-radius: 8px;
-    font-size: 1em;
+    border-radius: 0.75rem;
+    font-size: 1rem;
   }
-  
+
   input:focus {
     outline: none;
     border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
   }
-  
+
   button {
     width: 100%;
-    padding: 14px;
+    padding: clamp(0.85rem, 3vw, 1rem);
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     color: white;
     border: none;
-    border-radius: 8px;
-    font-size: 1.1em;
+    border-radius: 0.75rem;
+    font-size: clamp(1rem, 2vw, 1.15rem);
     font-weight: 600;
     cursor: pointer;
     transition: transform 0.2s;
   }
-  
+
   button:hover:not(:disabled) {
     transform: translateY(-2px);
   }
-  
+
   button:disabled {
     opacity: 0.6;
     cursor: not-allowed;
-  }
-
-  @media (max-width: 480px) {
-    .card { padding: 24px; }
-    h1 { font-size: 1.6em; }
-    h2 { font-size: 1.05em; }
-    .role-icon { font-size: 2.2em; }
   }
 </style>
 

--- a/src/routes/tracker/+page.svelte
+++ b/src/routes/tracker/+page.svelte
@@ -656,7 +656,7 @@ Total: $${weekPay.toFixed(2)}`
       </div>
       
       <!-- Mobile view toggle -->
-      <div class="mobile-view-toggle">
+      <div class="mobile-view-toggle mobile-only">
         <button class:active={mobileView === 'summary'} on:click={() => mobileView = 'summary'}>
           Summary
         </button>
@@ -669,7 +669,7 @@ Total: $${weekPay.toFixed(2)}`
         <div class="empty-state">No entries for this week</div>
       {:else}
         <!-- Desktop table view -->
-        <div class="desktop-table">
+        <div class="desktop-table desktop-only">
           <table>
             <thead>
               <tr>
@@ -706,68 +706,70 @@ Total: $${weekPay.toFixed(2)}`
         </div>
         
         <!-- Mobile card view -->
-        <div class="mobile-cards">
-          {#if mobileView === 'summary'}
-            <!-- Summary View -->
-            <div class="summary-grid">
-              {#each filteredEntries as entry}
-                <div class="entry-card">
-                  <div class="entry-header">
-                    <span class="entry-date">{formatDateShort(entry.clock_in)}</span>
-                    <span class="entry-hours">{(parseFloat(entry.hours) || 0).toFixed(1)}h</span>
-                  </div>
-                  <div class="entry-time">
-                    {formatTime(entry.clock_in)} - {formatTime(entry.clock_out)}
-                  </div>
-                  <div class="entry-earnings">
-                    ${((parseFloat(entry.hours) || 0) * (selectedNanny?.hourly_rate || 20)).toFixed(2)}
-                  </div>
-                  {#if profile?.role === 'family' || profile?.role === 'admin'}
-                    <div class="entry-actions">
-                      <button class="btn-sm btn-edit" on:click={() => editEntry(entry)}>Edit</button>
-                      <button class="btn-sm btn-danger" on:click={() => deleteEntry(entry.id)}>Delete</button>
+        <div class="mobile-only">
+          <div class="mobile-cards">
+            {#if mobileView === 'summary'}
+              <!-- Summary View -->
+              <div class="summary-grid">
+                {#each filteredEntries as entry}
+                  <div class="entry-card">
+                    <div class="entry-header">
+                      <span class="entry-date">{formatDateShort(entry.clock_in)}</span>
+                      <span class="entry-hours">{(parseFloat(entry.hours) || 0).toFixed(1)}h</span>
                     </div>
-                  {/if}
-                </div>
-              {/each}
-            </div>
-          {:else}
-            <!-- Details View -->
-            <div class="details-list">
-              {#each filteredEntries as entry}
-                <div class="detail-card">
-                  <div class="detail-row">
-                    <span class="detail-label">Date:</span>
-                    <span class="detail-value">{formatDate(entry.clock_in)}</span>
+                    <div class="entry-time">
+                      {formatTime(entry.clock_in)} - {formatTime(entry.clock_out)}
+                    </div>
+                    <div class="entry-earnings">
+                      ${((parseFloat(entry.hours) || 0) * (selectedNanny?.hourly_rate || 20)).toFixed(2)}
+                    </div>
+                    {#if profile?.role === 'family' || profile?.role === 'admin'}
+                      <div class="entry-actions">
+                        <button class="btn-sm btn-edit" on:click={() => editEntry(entry)}>Edit</button>
+                        <button class="btn-sm btn-danger" on:click={() => deleteEntry(entry.id)}>Delete</button>
+                      </div>
+                    {/if}
                   </div>
-                  <div class="detail-row">
-                    <span class="detail-label">In/Out:</span>
-                    <span class="detail-value">{formatTime(entry.clock_in)} - {formatTime(entry.clock_out)}</span>
-                  </div>
-                  <div class="detail-row">
-                    <span class="detail-label">Hours:</span>
-                    <span class="detail-value">{(parseFloat(entry.hours) || 0).toFixed(1)}</span>
-                  </div>
-                  <div class="detail-row">
-                    <span class="detail-label">Earnings:</span>
-                    <span class="detail-value">${((parseFloat(entry.hours) || 0) * (selectedNanny?.hourly_rate || 20)).toFixed(2)}</span>
-                  </div>
-                  {#if entry.notes}
+                {/each}
+              </div>
+            {:else}
+              <!-- Details View -->
+              <div class="details-list">
+                {#each filteredEntries as entry}
+                  <div class="detail-card">
                     <div class="detail-row">
-                      <span class="detail-label">Notes:</span>
-                      <span class="detail-value">{entry.notes}</span>
+                      <span class="detail-label">Date:</span>
+                      <span class="detail-value">{formatDate(entry.clock_in)}</span>
                     </div>
-                  {/if}
-                  {#if profile?.role === 'family' || profile?.role === 'admin'}
-                    <div class="detail-actions">
-                      <button class="btn-sm btn-edit" on:click={() => editEntry(entry)}>Edit</button>
-                      <button class="btn-sm btn-danger" on:click={() => deleteEntry(entry.id)}>Delete</button>
+                    <div class="detail-row">
+                      <span class="detail-label">In/Out:</span>
+                      <span class="detail-value">{formatTime(entry.clock_in)} - {formatTime(entry.clock_out)}</span>
                     </div>
-                  {/if}
-                </div>
-              {/each}
-            </div>
-          {/if}
+                    <div class="detail-row">
+                      <span class="detail-label">Hours:</span>
+                      <span class="detail-value">{(parseFloat(entry.hours) || 0).toFixed(1)}</span>
+                    </div>
+                    <div class="detail-row">
+                      <span class="detail-label">Earnings:</span>
+                      <span class="detail-value">${((parseFloat(entry.hours) || 0) * (selectedNanny?.hourly_rate || 20)).toFixed(2)}</span>
+                    </div>
+                    {#if entry.notes}
+                      <div class="detail-row">
+                        <span class="detail-label">Notes:</span>
+                        <span class="detail-value">{entry.notes}</span>
+                      </div>
+                    {/if}
+                    {#if profile?.role === 'family' || profile?.role === 'admin'}
+                      <div class="detail-actions">
+                        <button class="btn-sm btn-edit" on:click={() => editEntry(entry)}>Edit</button>
+                        <button class="btn-sm btn-danger" on:click={() => deleteEntry(entry.id)}>Delete</button>
+                      </div>
+                    {/if}
+                  </div>
+                {/each}
+              </div>
+            {/if}
+          </div>
         </div>
         
         <div class="week-total">
@@ -797,7 +799,7 @@ Total: $${weekPay.toFixed(2)}`
         <div class="empty-state">No payment records yet</div>
       {:else}
         <!-- Desktop table -->
-        <div class="desktop-table">
+        <div class="desktop-table desktop-only">
           <table>
             <thead>
               <tr>
@@ -848,42 +850,44 @@ Total: $${weekPay.toFixed(2)}`
         </div>
         
         <!-- Mobile payment cards -->
-        <div class="mobile-cards">
-          {#each payments as payment}
-            <div class="payment-card" class:paid={payment.is_paid}>
-              <div class="payment-header">
-                <span class="payment-week">{formatDateShort(payment.week_start)} - {formatDateShort(payment.week_end)}</span>
-                <span class="status-badge" class:paid={payment.is_paid}>
-                  {payment.is_paid ? 'Paid' : 'Unpaid'}
-                </span>
-              </div>
-              <div class="payment-details">
-                <div class="payment-row">
-                  <span>{payment.hours?.toFixed(1) || 0} hours</span>
-                  <span class="payment-amount">${payment.amount?.toFixed(2) || 0}</span>
+        <div class="mobile-only">
+          <div class="mobile-cards">
+            {#each payments as payment}
+              <div class="payment-card" class:paid={payment.is_paid}>
+                <div class="payment-header">
+                  <span class="payment-week">{formatDateShort(payment.week_start)} - {formatDateShort(payment.week_end)}</span>
+                  <span class="status-badge" class:paid={payment.is_paid}>
+                    {payment.is_paid ? 'Paid' : 'Unpaid'}
+                  </span>
                 </div>
-                {#if payment.paid_date}
-                  <div class="payment-date">Paid: {formatDateShort(payment.paid_date)}</div>
+                <div class="payment-details">
+                  <div class="payment-row">
+                    <span>{payment.hours?.toFixed(1) || 0} hours</span>
+                    <span class="payment-amount">${payment.amount?.toFixed(2) || 0}</span>
+                  </div>
+                  {#if payment.paid_date}
+                    <div class="payment-date">Paid: {formatDateShort(payment.paid_date)}</div>
+                  {/if}
+                </div>
+                {#if profile?.role === 'family' || profile?.role === 'admin'}
+                  <div class="payment-actions">
+                    {#if payment.is_paid}
+                      <button class="btn-sm btn-warning" on:click={() => markUnpaid(payment.id)}>
+                        Mark Unpaid
+                      </button>
+                    {:else}
+                      <button class="btn-sm btn-success" on:click={() => markPaid(payment.id)}>
+                        Mark Paid
+                      </button>
+                    {/if}
+                    <button class="btn-sm btn-danger" on:click={() => deletePayment(payment.id)}>
+                      Delete
+                    </button>
+                  </div>
                 {/if}
               </div>
-              {#if profile?.role === 'family' || profile?.role === 'admin'}
-                <div class="payment-actions">
-                  {#if payment.is_paid}
-                    <button class="btn-sm btn-warning" on:click={() => markUnpaid(payment.id)}>
-                      Mark Unpaid
-                    </button>
-                  {:else}
-                    <button class="btn-sm btn-success" on:click={() => markPaid(payment.id)}>
-                      Mark Paid
-                    </button>
-                  {/if}
-                  <button class="btn-sm btn-danger" on:click={() => deletePayment(payment.id)}>
-                    Delete
-                  </button>
-                </div>
-              {/if}
-            </div>
-          {/each}
+            {/each}
+          </div>
         </div>
       {/if}
     </div>
@@ -956,44 +960,30 @@ Total: $${weekPay.toFixed(2)}`
 {/if}
 
 <style>
-  .container {
-    min-height: 100vh;
-    background: #f7fafc;
-    padding: 40px 20px;
-    max-width: 1200px;
-    margin: 0 auto;
-  }
-  
   .nanny-selector {
     background: white;
-    padding: 20px;
-    border-radius: 15px;
-    margin-bottom: 20px;
+    padding: clamp(1.25rem, 4vw, 1.75rem);
+    border-radius: clamp(0.75rem, 2vw, 1rem);
+    margin-bottom: var(--section-gap);
     box-shadow: 0 2px 10px rgba(0,0,0,0.1);
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
-    gap: 15px;
+    gap: var(--stack-gap);
   }
-  
+
   .nanny-selector label {
     font-weight: 600;
     color: #4a5568;
+    min-width: 140px;
   }
-  
+
   .nanny-selector select {
-    flex: 1;
-    padding: 12px;
+    flex: 1 1 220px;
+    padding: 0.75rem;
     border: 2px solid #e2e8f0;
-    border-radius: 8px;
-    font-size: 1em;
-  }
-  
-  .card {
-    background: white;
-    border-radius: 15px;
-    padding: 30px;
-    margin-bottom: 20px;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    border-radius: 0.75rem;
+    font-size: 1rem;
   }
   
   .card-header {
@@ -1020,38 +1010,40 @@ Total: $${weekPay.toFixed(2)}`
   
   .week-nav {
     display: flex;
-    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: center;
     align-items: center;
+    gap: var(--stack-gap);
   }
-  
+
   .week-nav button {
-    padding: 8px 16px;
+    padding: clamp(0.5rem, 2vw, 0.75rem) clamp(0.75rem, 3vw, 1.25rem);
     background: white;
     border: 2px solid #e2e8f0;
-    border-radius: 6px;
+    border-radius: 0.75rem;
     cursor: pointer;
     font-weight: 600;
   }
-  
+
   .week-nav button:hover {
     background: #f7fafc;
   }
-  
+
   .week-nav span {
     font-size: 0.95em;
     font-weight: 600;
     color: #4a5568;
-    min-width: 200px;
+    min-width: min(220px, 100%);
     text-align: center;
   }
   
   .timer-card {
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     color: white;
-    padding: 40px;
-    border-radius: 15px;
+    padding: clamp(2rem, 6vw, 2.75rem);
+    border-radius: clamp(0.75rem, 2vw, 1rem);
     text-align: center;
-    margin-bottom: 30px;
+    margin-bottom: 2rem;
   }
   
   .timer-label {
@@ -1062,7 +1054,7 @@ Total: $${weekPay.toFixed(2)}`
   }
   
   .timer {
-    font-size: 3.5em;
+    font-size: clamp(2.75rem, 8vw, 3.75rem);
     font-weight: bold;
     font-family: 'SF Mono', Monaco, monospace;
   }
@@ -1087,11 +1079,11 @@ Total: $${weekPay.toFixed(2)}`
   }
   
   .btn {
-    padding: 16px 40px;
-    font-size: 1.2em;
-    font-weight: bold;
+    padding: clamp(0.9rem, 3vw, 1.1rem) clamp(1.75rem, 5vw, 2.5rem);
+    font-size: clamp(1rem, 2.5vw, 1.2rem);
+    font-weight: 700;
     border: none;
-    border-radius: 10px;
+    border-radius: 0.85rem;
     cursor: pointer;
     transition: all 0.3s;
   }
@@ -1118,13 +1110,13 @@ Total: $${weekPay.toFixed(2)}`
   
   .quick-actions {
     display: flex;
-    gap: 10px;
     justify-content: center;
     flex-wrap: wrap;
+    gap: var(--stack-gap);
   }
   
   .btn-secondary {
-    padding: 10px 20px;
+    padding: clamp(0.75rem, 3vw, 0.9rem) clamp(1.25rem, 4vw, 1.75rem);
     font-size: 0.95em;
     background: #718096;
     color: white;
@@ -1137,23 +1129,23 @@ Total: $${weekPay.toFixed(2)}`
   
   /* Mobile view toggle */
   .mobile-view-toggle {
-    display: none;
-    gap: 10px;
-    margin-bottom: 20px;
+    display: flex;
+    gap: var(--stack-gap);
+    margin-bottom: var(--stack-gap);
   }
-  
+
   .mobile-view-toggle button {
     flex: 1;
-    padding: 10px;
+    padding: clamp(0.75rem, 3vw, 0.9rem);
     background: white;
     border: 2px solid #e2e8f0;
-    border-radius: 6px;
+    border-radius: 0.75rem;
     font-weight: 600;
     color: #4a5568;
     cursor: pointer;
     transition: all 0.2s;
   }
-  
+
   .mobile-view-toggle button.active {
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     color: white;
@@ -1189,14 +1181,17 @@ Total: $${weekPay.toFixed(2)}`
     background: #f7fafc;
   }
   
-  /* Mobile cards - hidden by default */
+  /* Mobile cards */
   .mobile-cards {
-    display: none;
+    display: flex;
+    flex-direction: column;
+    gap: var(--stack-gap);
   }
-  
+
   .summary-grid {
     display: grid;
-    gap: 15px;
+    gap: var(--grid-gap);
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   }
   
   .entry-card {
@@ -1241,7 +1236,8 @@ Total: $${weekPay.toFixed(2)}`
   
   .entry-actions {
     display: flex;
-    gap: 8px;
+    flex-wrap: wrap;
+    gap: var(--stack-gap);
   }
   
   .detail-card {
@@ -1277,7 +1273,8 @@ Total: $${weekPay.toFixed(2)}`
     padding-top: 15px;
     border-top: 1px solid #e2e8f0;
     display: flex;
-    gap: 8px;
+    flex-wrap: wrap;
+    gap: var(--stack-gap);
   }
   
   /* Payment cards */
@@ -1328,7 +1325,8 @@ Total: $${weekPay.toFixed(2)}`
   
   .payment-actions {
     display: flex;
-    gap: 8px;
+    flex-wrap: wrap;
+    gap: var(--stack-gap);
     margin-top: 10px;
     padding-top: 10px;
     border-top: 1px solid #e2e8f0;
@@ -1475,20 +1473,19 @@ Total: $${weekPay.toFixed(2)}`
   
   .form-row {
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 15px;
+    gap: var(--stack-gap);
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
   
   .button-row {
     display: flex;
-    gap: 10px;
-    margin-top: 20px;
+    flex-wrap: wrap;
+    gap: var(--stack-gap);
+    margin-top: var(--stack-gap);
   }
-  
+
   .button-row .btn {
-    flex: 1;
-    padding: 12px;
-    font-size: 1em;
+    flex: 1 1 min(220px, 100%);
   }
   
   .clock-in-confirm {
@@ -1500,103 +1497,4 @@ Total: $${weekPay.toFixed(2)}`
     font-size: 1.1em;
   }
   
-  /* Mobile responsive styles */
-  @media (max-width: 768px) {
-    .container {
-      padding: 20px 12px;
-    }
-    
-    .card {
-      padding: 20px;
-    }
-    
-    .timer-card {
-      padding: 30px 20px;
-    }
-    
-    .timer {
-      font-size: 2.5em;
-    }
-    
-    .btn {
-      padding: 14px 28px;
-      font-size: 1.1em;
-    }
-    
-    .week-nav span {
-      min-width: auto;
-      font-size: 0.85em;
-    }
-    
-    .week-nav button {
-      padding: 8px 12px;
-    }
-    
-    /* Hide desktop table, show mobile cards */
-    .desktop-table {
-      display: none;
-    }
-    
-    .mobile-cards {
-      display: block;
-    }
-    
-    .mobile-view-toggle {
-      display: flex;
-    }
-    
-    .quick-actions {
-      gap: 8px;
-    }
-    
-    .btn-secondary {
-      padding: 10px 16px;
-      font-size: 0.9em;
-    }
-    
-    .modal-content {
-      padding: 20px;
-    }
-    
-    .form-row {
-      grid-template-columns: 1fr;
-    }
-    
-    .week-total {
-      padding: 15px;
-    }
-    
-    .total-amount {
-      font-size: 1.5em;
-    }
-  }
-  
-  @media (max-width: 480px) {
-    .nanny-selector {
-      flex-direction: column;
-      align-items: stretch;
-    }
-    
-    .card-header {
-      flex-direction: column;
-      align-items: stretch;
-      text-align: center;
-    }
-    
-    .week-nav {
-      width: 100%;
-      justify-content: space-between;
-    }
-    
-    .btn-sm {
-      font-size: 0.8em;
-      padding: 5px 10px;
-    }
-    
-    .entry-actions,
-    .detail-actions,
-    .payment-actions {
-      flex-wrap: wrap;
-    }
-  }
 </style>


### PR DESCRIPTION
## Summary
- add global spacing utilities and fluid typography variables to reduce per-page mobile overrides
- restyle the auth, setup, settings, schedule, and tracker views to use the shared mobile responsive scales
- simplify tracker markup so desktop tables use `desktop-only` while mobile cards live under `mobile-only`

## Testing
- `npm run lint` *(fails: repository has existing Prettier formatting issues across multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68e42d8f1e3c8330b0ceb374ebfad422