### PR TITLE
Replace .single() with .maybeSingle() for profile queries

### DIFF
--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -25,7 +25,7 @@
         .from('profiles')
         .select('role')
         .eq('id', user.id)
-        .single()
+        .maybeSingle()
       
       isAdmin = profile?.role === 'admin'
       userRole = profile?.role || null

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -32,10 +32,10 @@
       .from('profiles')
       .select('*')
       .eq('id', user.id)
-      .single()
-    
+      .maybeSingle()
+
     profile = profileData
-    
+
     // Only admin can access this page
     if (profile?.role !== 'admin') {
       alert('Access denied. Admin only.')

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -137,8 +137,8 @@ onMount(async () => {
     .from('profiles')
     .select('*')
     .eq('id', user.id)
-    .single()
-  
+    .maybeSingle()
+
   profile = profileData
 
   // If no profile or missing role, send to setup
@@ -207,10 +207,12 @@ async function loadFamilyDashboard() {
       .is('clock_out', null)
       .order('clock_in', { ascending: false })
       .limit(1)
-      .single()
-    
+      .maybeSingle()
+
     if (shiftData) {
       activeShifts = [shiftData]
+    } else {
+      activeShifts = []
     }
   }
   // Update your subscribeToShifts function to handle cleanup properly

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -39,10 +39,10 @@
       .from('profiles')
       .select('*')
       .eq('id', user.id)
-      .single()
-    
+      .maybeSingle()
+
     profile = profileData
-    
+
     // If family or admin, load all nannies for the filter dropdown
     if (profile?.role === 'family' || profile?.role === 'admin') {
       const { data: nanniesData } = await supabase

--- a/src/routes/schedule/+page.svelte
+++ b/src/routes/schedule/+page.svelte
@@ -44,8 +44,8 @@
       .from('profiles')
       .select('*')
       .eq('id', user.id)
-      .single()
-    
+      .maybeSingle()
+
     profile = profileData
 
     if (profile?.role === 'family' || profile?.role === 'admin') {

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -29,10 +29,10 @@
       .from('profiles')
       .select('*')
       .eq('id', user.id)
-      .single()
-    
+      .maybeSingle()
+
     profile = profileData
-    
+
     // Populate form
     if (profile) {
       fullName = profile.full_name || ''
@@ -77,7 +77,7 @@
         .from('profiles')
         .select('*')
         .eq('id', user.id)
-        .single()
+        .maybeSingle()
       
       profile = updatedProfile
     } catch (err) {

--- a/src/routes/tracker/+page.svelte
+++ b/src/routes/tracker/+page.svelte
@@ -46,10 +46,10 @@
       .from('profiles')
       .select('*')
       .eq('id', user.id)
-      .single()
-    
+      .maybeSingle()
+
     profile = profileData
-    
+
     // Load nannies for family/admin
     if (profile?.role === 'family' || profile?.role === 'admin') {
       const { data: nanniesData } = await supabase


### PR DESCRIPTION
## Summary
Updated all profile queries throughout the application to use `.maybeSingle()` instead of `.single()`. This change makes the queries more resilient by returning `null` instead of throwing an error when no profile record is found.

## Key Changes
- Replaced `.single()` with `.maybeSingle()` in profile queries across all route pages:
  - `src/routes/dashboard/+page.svelte`
  - `src/routes/settings/+page.svelte`
  - `src/routes/admin/+page.svelte`
  - `src/routes/history/+page.svelte`
  - `src/routes/tracker/+page.svelte`
  - `src/routes/schedule/+page.svelte`
  - `src/lib/Nav.svelte`
- Added explicit `else` clause in `loadFamilyDashboard()` to set `activeShifts = []` when no shift data is found
- Replaced `.single()` with `.maybeSingle()` for the active shift query in the dashboard
- Fixed trailing whitespace inconsistencies throughout the modified files

## Implementation Details
The `.maybeSingle()` method is more appropriate for these queries since:
- It gracefully handles cases where a profile may not exist yet (e.g., new users)
- It returns `null` instead of throwing an error, allowing the application to handle missing profiles with conditional logic
- The existing code already checks `if (profile)` or `if (profile?.role)`, making it compatible with nullable results

https://claude.ai/code/session_01DMC7xKDr1Gj9X6gsAsyLaD