### PR TITLE
Fix calendar sync "Calendar not found" when service role key is missing

### DIFF
--- a/src/lib/server/supabase.js
+++ b/src/lib/server/supabase.js
@@ -8,11 +8,23 @@ const supabaseServiceKey = env.SUPABASE_SERVICE_ROLE_KEY
  * Create a server-side Supabase client that uses the service role key
  * for operations that need to bypass RLS (like syncing calendar events).
  * Falls back to the anon key if service role key isn't set.
+ *
+ * If a userToken is provided, it's sent as the Authorization header so
+ * that RLS policies see the correct auth.uid(). This is important when
+ * the service role key isn't configured (e.g. local dev).
  */
-export function createServerClient() {
+export function createServerClient(userToken) {
   const key = supabaseServiceKey || env.VITE_SUPABASE_ANON_KEY
   if (!supabaseUrl || !key) {
     throw new Error('Missing Supabase environment variables on server.')
   }
-  return createClient(supabaseUrl, key)
+
+  const options = {}
+  if (!supabaseServiceKey && userToken) {
+    options.global = {
+      headers: { Authorization: `Bearer ${userToken}` }
+    }
+  }
+
+  return createClient(supabaseUrl, key, options)
 }

--- a/src/routes/api/calendar/sync/+server.js
+++ b/src/routes/api/calendar/sync/+server.js
@@ -10,16 +10,16 @@ import { fetchAndParseICal } from '$lib/server/ical-parser.js'
  * Requires authenticated user (passed via authorization header).
  */
 export async function POST({ request }) {
-  const supabase = createServerClient()
-
   // Get auth token from request
   const authHeader = request.headers.get('authorization')
   if (!authHeader) {
     return json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  // Verify the user
   const token = authHeader.replace('Bearer ', '')
+  const supabase = createServerClient(token)
+
+  // Verify the user
   const { data: { user }, error: authError } = await supabase.auth.getUser(token)
   if (authError || !user) {
     return json({ error: 'Unauthorized' }, { status: 401 })


### PR DESCRIPTION
The sync endpoint creates a server-side Supabase client. Without the SUPABASE_SERVICE_ROLE_KEY set (common in dev), it fell back to the anon key but had no user context, so RLS blocked the query and the calendar row was invisible — causing "Calendar not found."

Now the user's JWT token is passed to createServerClient() and used as the Authorization header when the service role key isn't available, so RLS correctly resolves auth.uid() and the query works.

https://claude.ai/code/session_018iH9aKm9SX8erjG67kaZV9