### PR TITLE
Fix SSR issues and improve manual busy times query logic

### DIFF
--- a/src/routes/api/calendar/sync/+server.js
+++ b/src/routes/api/calendar/sync/+server.js
@@ -26,7 +26,13 @@ export async function POST({ request }) {
   }
 
   // Get request body
-  const { calendarId } = await request.json()
+  let calendarId
+  try {
+    const body = await request.json()
+    calendarId = body.calendarId
+  } catch {
+    return json({ error: 'Invalid request body' }, { status: 400 })
+  }
   if (!calendarId) {
     return json({ error: 'calendarId is required' }, { status: 400 })
   }

--- a/src/routes/schedule/+page.js
+++ b/src/routes/schedule/+page.js
@@ -1,0 +1,4 @@
+// This page is entirely client-rendered (all data loading happens in onMount
+// behind auth). Disabling SSR avoids server-side errors from browser-only APIs
+// like document/window and removes unnecessary server work.
+export const ssr = false

--- a/src/routes/schedule/+page.svelte
+++ b/src/routes/schedule/+page.svelte
@@ -104,7 +104,9 @@
 
   let mqlCleanup = null
   onDestroy(() => {
-    document.body.classList.remove('schedule-active')
+    if (typeof document !== 'undefined') {
+      document.body.classList.remove('schedule-active')
+    }
     if (mqlCleanup) mqlCleanup()
   })
 
@@ -145,11 +147,13 @@
 
       if (error) throw error
 
+      // Fetch non-recurring manual busy times within this week,
+      // plus all recurring events (their start_time is the first occurrence,
+      // which may be in the past, so we can't filter by date range).
       const { data: manualTimes, error: manualError } = await supabase
         .from('manual_busy_times')
         .select('*')
-        .gte('start_time', currentWeekStart.toISOString())
-        .lte('start_time', weekEnd.toISOString())
+        .or(`and(start_time.gte.${currentWeekStart.toISOString()},start_time.lte.${weekEnd.toISOString()}),recurring.eq.true`)
 
       if (manualError) throw manualError
 


### PR DESCRIPTION
## Summary
This PR addresses server-side rendering (SSR) compatibility issues and improves the manual busy times filtering logic to properly handle recurring events.

## Key Changes

- **Disable SSR for schedule page** (`src/routes/schedule/+page.js`): Added `export const ssr = false` to prevent server-side rendering errors from browser-only APIs like `document` and `window`, since all data loading happens client-side behind authentication.

- **Add document safety check** (`src/routes/schedule/+page.svelte`): Wrapped `document.body.classList.remove()` in a `typeof document !== 'undefined'` check in the `onDestroy` hook to prevent errors in SSR contexts.

- **Fix manual busy times query** (`src/routes/schedule/+page.svelte`): Updated the Supabase query to use an `or` filter that fetches:
  - Non-recurring manual busy times within the current week, OR
  - All recurring events (since their `start_time` represents the first occurrence which may be in the past)
  
  This replaces the previous simple date range filter that would miss recurring events.

- **Improve error handling** (`src/routes/api/calendar/sync/+server.js`): Added try-catch block around `request.json()` to gracefully handle invalid JSON in request bodies with a 400 error response.

## Implementation Details

The manual busy times query change uses Supabase's `or` operator with the syntax: `or(and(start_time.gte...,start_time.lte...),recurring.eq.true)` to properly combine the date range filter for non-recurring events with the inclusion of all recurring events.

https://claude.ai/code/session_01Rr31mjVhAyAHuPJ9YvH9BV